### PR TITLE
Fixed use of format in MTIImage creation from UIImage

### DIFF
--- a/Frameworks/MetalPetal/MTIImage.swift
+++ b/Frameworks/MetalPetal/MTIImage.swift
@@ -180,7 +180,7 @@ extension MTIImage {
             let format = UIGraphicsImageRendererFormat.preferred()
             format.opaque = isOpaque
             format.scale = image.scale
-            cgImage = UIGraphicsImageRenderer(size: image.size).image { _ in
+            cgImage = UIGraphicsImageRenderer(size: image.size, format: format).image { _ in
                 image.draw(at: .zero)
             }.cgImage!
             orientation = .up


### PR DESCRIPTION
The `format` variable was created but not used, and this mainly caused scale to be `2` and resulting image to be 2 times larger than the image it is created from.